### PR TITLE
fix in huggingface_hub version

### DIFF
--- a/v1/003_Deployment/model_to_api/container/Dockerfile
+++ b/v1/003_Deployment/model_to_api/container/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
 # These optimizations save a fair amount of space in the image, which reduces start up time.
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && \
     pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu && \
-    pip install --no-cache-dir tensorflow==2.13.0 transformers==4.35.2 sentence-transformers==2.2.2 pandas numpy flask gevent gunicorn && \
+    pip install --no-cache-dir tensorflow==2.13.0 transformers==4.35.2 sentence-transformers==2.2.2 huggingface_hub==0.25.2 pandas numpy flask gevent gunicorn && \
     rm -rf /root/.cache
 
 # 3. Set some environment variables. PYTHONUNBUFFERED keeps Python from buffering our standard


### PR DESCRIPTION
fixed error "ImportError: cannot import name 'cached_download' from ' huggingface_hub" for sentence-transformers==2.2.2 is required huggingface_hub==0.25.2


traceback in my local deploy
```
openalex_topic_ai  |   File "/opt/program/wsgi.py", line 1, in <module>
openalex_topic_ai  |     import predictor as myapp
openalex_topic_ai  |   File "/opt/program/predictor.py", line 15, in <module>
openalex_topic_ai  |     from sentence_transformers import SentenceTransformer
openalex_topic_ai  |   File "/usr/local/lib/python3.8/dist-packages/sentence_transformers/__init__.py", line 3, in <module>
openalex_topic_ai  |     from .datasets import SentencesDataset, ParallelSentencesDataset
openalex_topic_ai  |   File "/usr/local/lib/python3.8/dist-packages/sentence_transformers/datasets/__init__.py", line 3, in <module>
openalex_topic_ai  |     from .ParallelSentencesDataset import ParallelSentencesDataset
openalex_topic_ai  |   File "/usr/local/lib/python3.8/dist-packages/sentence_transformers/datasets/ParallelSentencesDataset.py", line 4, in <module>
openalex_topic_ai  |     from .. import SentenceTransformer
openalex_topic_ai  |   File "/usr/local/lib/python3.8/dist-packages/sentence_transformers/SentenceTransformer.py", line 12, in <module>
openalex_topic_ai  |     from huggingface_hub import HfApi, HfFolder, Repository, hf_hub_url, cached_download
openalex_topic_ai  | ImportError: cannot import name 'cached_download' from 'huggingface_hub' (/usr/local/lib/python3.8/dist-packages/huggingface_hub/__init__.py)
```